### PR TITLE
Update run path instruction to match PIO v4

### DIFF
--- a/examples/hello-world/README.rst
+++ b/examples/hello-world/README.rst
@@ -26,7 +26,7 @@ How to build PlatformIO based project
     > platformio run
 
     # Run program
-    > .pioenvs/native/program
+    > .pio\build\windows_x86\program.exe
 
     # Clean build files
     > platformio run --target clean


### PR DESCRIPTION
Update run path instruction to match PIO v4 change from `.piolib` to `.pio`. Also, environment is `windows_x86`, not `native`.

Was brought to my attention by [this forum post](https://community.platformio.org/t/vscode-pio-x86-windows-error-executing/13224). 