### PR TITLE
Add `upload` / `exec` Target

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -61,6 +61,16 @@ elif get_systype() in ("linux_x86_64", "linux_i686"):
 target_bin = env.BuildProgram()
 
 #
+# Target: Execute binary
+#
+
+exec_action = env.VerboseAction(
+    "$SOURCE $PROGRAM_ARGS", "Executing $SOURCE")
+
+AlwaysBuild(env.Alias("exec", target_bin, exec_action))
+AlwaysBuild(env.Alias("upload", target_bin, exec_action))
+
+#
 # Target: Print binary size
 #
 


### PR DESCRIPTION
This PR adds a `upload` / `exec` target, so clicking `upload` in the VSCode IDE will build and run the program.